### PR TITLE
Attach pids to targets

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -104,9 +104,9 @@ ebpf_module_t ebpf_modules[] = {
 };
 
 //Link with apps.plugin
-struct target
-    *apps_groups_default_target = NULL, // the default target
-    *apps_groups_root_target = NULL;    // apps_groups.conf defined
+// struct target
+//     *apps_groups_default_target = NULL, // the default target
+//     *apps_groups_root_target = NULL;    // apps_groups.conf defined
 
 /*****************************************************************
  *

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -21,13 +21,13 @@
 # include <dirent.h>
 
 //From libnetdata.h
-# include "../../libnetdata/threads/threads.h"
-# include "../../libnetdata/locks/locks.h"
-# include "../../libnetdata/avl/avl.h"
-# include "../../libnetdata/clocks/clocks.h"
-# include "../../libnetdata/config/appconfig.h"
-# include "../../libnetdata/ebpf/ebpf.h"
-# include "../../daemon/main.h"
+# include "libnetdata/threads/threads.h"
+# include "libnetdata/locks/locks.h"
+# include "libnetdata/avl/avl.h"
+# include "libnetdata/clocks/clocks.h"
+# include "libnetdata/config/appconfig.h"
+# include "libnetdata/ebpf/ebpf.h"
+# include "daemon/main.h"
 
 # include "ebpf_apps.h"
 
@@ -169,7 +169,5 @@ void ebpf_create_charts_on_apps(char *name, char *axis, char *web, int order, st
 //Common variables
 extern char *ebpf_user_config_dir;
 extern char *ebpf_stock_config_dir;
-extern struct target *apps_groups_default_target;
-extern struct target *apps_groups_root_target;
 
 #endif

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -454,3 +454,588 @@ int ebpf_read_apps_groups_conf(struct target **apps_groups_default_target, struc
 
     return 0;
 }
+
+// the minimum PID of the system
+// this is also the pid of the init process
+#define INIT_PID 1
+
+// ----------------------------------------------------------------------------
+// string lengths
+
+#define MAX_COMPARE_NAME 100
+#define MAX_NAME 100
+#define MAX_CMDLINE 16384
+
+static struct pid_stat
+        *root_of_pids = NULL,   // global list of all processes running
+        **all_pids = NULL;      // to avoid allocations, we pre-allocate the
+                                // the entire pid space.
+
+static size_t
+        all_pids_count = 0;     // the number of processes running
+
+struct target
+        *apps_groups_default_target = NULL, // the default target
+        *apps_groups_root_target = NULL,    // apps_groups.conf defined
+        *users_root_target = NULL,          // users
+        *groups_root_target = NULL;         // user groups
+
+size_t
+        apps_groups_targets_count = 0;       // # of apps_groups.conf targets
+
+// ----------------------------------------------------------------------------
+// internal flags
+// handled in code (automatically set)
+
+static int
+        proc_pid_cmdline_is_needed = 0; // 1 when we need to read /proc/cmdline
+
+// ----------------------------------------------------------------------------
+// internal counters
+
+static size_t
+        // global_iterations_counter = 1,
+        calls_counter = 0,
+        // file_counter = 0,
+        // filenames_allocated_counter = 0,
+        // inodes_changed_counter = 0,
+        // links_changed_counter = 0,
+        targets_assignment_counter = 0;
+
+// ----------------------------------------------------------------------------
+// debugging
+
+// log each problem once per process
+// log flood protection flags (log_thrown)
+#define PID_LOG_IO      0x00000001
+#define PID_LOG_STATUS  0x00000002
+#define PID_LOG_CMDLINE 0x00000004
+#define PID_LOG_FDS     0x00000008
+#define PID_LOG_STAT    0x00000010
+
+static int debug_enabled = 0;
+static inline void debug_log_int(const char *fmt, ... ) {
+    va_list args;
+
+    fprintf( stderr, "apps.plugin: ");
+    va_start( args, fmt );
+    vfprintf( stderr, fmt, args );
+    va_end( args );
+
+    fputc('\n', stderr);
+}
+
+#ifdef NETDATA_INTERNAL_CHECKS
+
+#define debug_log(fmt, args...) do { if(unlikely(debug_enabled)) debug_log_int(fmt, ##args); } while(0)
+
+#else
+
+static inline void debug_log_dummy(void) {}
+#define debug_log(fmt, args...) debug_log_dummy()
+
+#endif
+
+static inline int managed_log(struct pid_stat *p, uint32_t log, int status) {
+    if(unlikely(!status)) {
+        // error("command failed log %u, errno %d", log, errno);
+
+        if(unlikely(debug_enabled || errno != ENOENT)) {
+            if(unlikely(debug_enabled || !(p->log_thrown & log))) {
+                p->log_thrown |= log;
+                switch(log) {
+                    case PID_LOG_IO:
+                        error("Cannot process %s/proc/%d/io (command '%s')", netdata_configured_host_prefix, p->pid, p->comm);
+                        break;
+
+                    case PID_LOG_STATUS:
+                        error("Cannot process %s/proc/%d/status (command '%s')", netdata_configured_host_prefix, p->pid, p->comm);
+                        break;
+
+                    case PID_LOG_CMDLINE:
+                        error("Cannot process %s/proc/%d/cmdline (command '%s')", netdata_configured_host_prefix, p->pid, p->comm);
+                        break;
+
+                    case PID_LOG_FDS:
+                        error("Cannot process entries in %s/proc/%d/fd (command '%s')", netdata_configured_host_prefix, p->pid, p->comm);
+                        break;
+
+                    case PID_LOG_STAT:
+                        break;
+
+                    default:
+                        error("unhandled error for pid %d, command '%s'", p->pid, p->comm);
+                        break;
+                }
+            }
+        }
+        errno = 0;
+    }
+    else if(unlikely(p->log_thrown & log)) {
+        // error("unsetting log %u on pid %d", log, p->pid);
+        p->log_thrown &= ~log;
+    }
+
+    return status;
+}
+
+static inline struct pid_stat *get_pid_entry(pid_t pid) {
+    if(unlikely(all_pids[pid]))
+        return all_pids[pid];
+
+    struct pid_stat *p = callocz(sizeof(struct pid_stat), 1);
+
+    if(likely(root_of_pids))
+        root_of_pids->prev = p;
+
+    p->next = root_of_pids;
+    root_of_pids = p;
+
+    p->pid = pid;
+
+    all_pids[pid] = p;
+    all_pids_count++;
+
+    return p;
+}
+
+static inline void assign_target_to_pid(struct pid_stat *p) {
+    targets_assignment_counter++;
+
+    uint32_t hash = simple_hash(p->comm);
+    size_t pclen  = strlen(p->comm);
+
+    struct target *w;
+    for(w = apps_groups_root_target; w ; w = w->next) {
+        // if(debug_enabled || (p->target && p->target->debug_enabled)) debug_log_int("\t\tcomparing '%s' with '%s'", w->compare, p->comm);
+
+        // find it - 4 cases:
+        // 1. the target is not a pattern
+        // 2. the target has the prefix
+        // 3. the target has the suffix
+        // 4. the target is something inside cmdline
+
+        if(unlikely(( (!w->starts_with && !w->ends_with && w->comparehash == hash && !strcmp(w->compare, p->comm))
+                      || (w->starts_with && !w->ends_with && !strncmp(w->compare, p->comm, w->comparelen))
+                      || (!w->starts_with && w->ends_with && pclen >= w->comparelen && !strcmp(w->compare, &p->comm[pclen - w->comparelen]))
+                      || (proc_pid_cmdline_is_needed && w->starts_with && w->ends_with && p->cmdline && strstr(p->cmdline, w->compare))
+                    ))) {
+
+            if(w->target) p->target = w->target;
+            else p->target = w;
+
+            if(debug_enabled || (p->target && p->target->debug_enabled))
+                debug_log_int("%s linked to target %s", p->comm, p->target->name);
+
+            break;
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// update pids from proc
+
+static inline int read_proc_pid_cmdline(struct pid_stat *p) {
+    static char cmdline[MAX_CMDLINE + 1];
+
+    if(unlikely(!p->cmdline_filename)) {
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/proc/%d/cmdline", netdata_configured_host_prefix, p->pid);
+        p->cmdline_filename = strdupz(filename);
+    }
+
+    int fd = open(p->cmdline_filename, procfile_open_flags, 0666);
+    if(unlikely(fd == -1)) goto cleanup;
+
+    ssize_t i, bytes = read(fd, cmdline, MAX_CMDLINE);
+    close(fd);
+
+    if(unlikely(bytes < 0)) goto cleanup;
+
+    cmdline[bytes] = '\0';
+    for(i = 0; i < bytes ; i++) {
+        if(unlikely(!cmdline[i])) cmdline[i] = ' ';
+    }
+
+    if(p->cmdline) freez(p->cmdline);
+    p->cmdline = strdupz(cmdline);
+
+    debug_log("Read file '%s' contents: %s", p->cmdline_filename, p->cmdline);
+
+    return 1;
+
+cleanup:
+    // copy the command to the command line
+    if(p->cmdline) freez(p->cmdline);
+    p->cmdline = strdupz(p->comm);
+    return 0;
+}
+
+static inline int read_proc_pid_stat(struct pid_stat *p, void *ptr) {
+    (void)ptr;
+
+    static procfile *ff = NULL;
+
+    if(unlikely(!p->stat_filename)) {
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/proc/%d/stat", netdata_configured_host_prefix, p->pid);
+        p->stat_filename = strdupz(filename);
+    }
+
+    int set_quotes = (!ff)?1:0;
+
+    ff = procfile_reopen(ff, p->stat_filename, NULL, PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
+    if(unlikely(!ff)) return 0;
+
+    if(unlikely(set_quotes))
+        procfile_set_open_close(ff, "(", ")");
+
+    ff = procfile_readall(ff);
+    if(unlikely(!ff)) return 0;
+
+    p->last_stat_collected_usec = p->stat_collected_usec;
+    p->stat_collected_usec = now_monotonic_usec();
+    calls_counter++;
+
+    char *comm          = procfile_lineword(ff, 0, 1);
+    p->ppid             = (int32_t)str2pid_t(procfile_lineword(ff, 0, 3));
+
+    if(strcmp(p->comm, comm) != 0) {
+        if(unlikely(debug_enabled)) {
+            if(p->comm[0])
+                debug_log("\tpid %d (%s) changed name to '%s'", p->pid, p->comm, comm);
+            else
+                debug_log("\tJust added %d (%s)", p->pid, comm);
+        }
+
+        strncpyz(p->comm, comm, MAX_COMPARE_NAME);
+
+        // /proc/<pid>/cmdline
+        if(likely(proc_pid_cmdline_is_needed))
+            managed_log(p, PID_LOG_CMDLINE, read_proc_pid_cmdline(p));
+
+        assign_target_to_pid(p);
+    }
+
+    if(unlikely(debug_enabled || (p->target && p->target->debug_enabled)))
+        debug_log_int(
+            "READ PROC/PID/STAT: %s/proc/%d/stat, process: '%s' on target '%s' (dt=%llu)",
+            netdata_configured_host_prefix, p->pid, p->comm, (p->target) ? p->target->name : "UNSET",
+            p->stat_collected_usec - p->last_stat_collected_usec);
+
+    return 0;
+}
+
+static inline int collect_data_for_pid(pid_t pid, void *ptr) {
+    if(unlikely(pid < 0 || pid > pid_max)) {
+        error("Invalid pid %d read (expected %d to %d). Ignoring process.", pid, 0, pid_max);
+        return 0;
+    }
+
+    struct pid_stat *p = get_pid_entry(pid);
+    if(unlikely(!p || p->read)) return 0;
+    p->read = 1;
+
+    if(unlikely(!managed_log(p, PID_LOG_STAT, read_proc_pid_stat(p, ptr))))
+        // there is no reason to proceed if we cannot get its status
+        return 0;
+
+    // check its parent pid
+    if(unlikely(p->ppid < 0 || p->ppid > pid_max)) {
+        error("Pid %d (command '%s') states invalid parent pid %d. Using 0.", pid, p->comm, p->ppid);
+        p->ppid = 0;
+    }
+
+    if(unlikely(debug_enabled && all_pids_count && p->ppid && all_pids[p->ppid] && !all_pids[p->ppid]->read))
+        debug_log("Read process %d (%s) sortlisted %d, but its parent %d (%s) sortlisted %d, is not read", p->pid, p->comm, p->sortlist, all_pids[p->ppid]->pid, all_pids[p->ppid]->comm, all_pids[p->ppid]->sortlist);
+
+    // mark it as updated
+    p->updated = 1;
+    p->keep = 0;
+    p->keeploops = 0;
+
+    return 1;
+}
+
+static inline void link_all_processes_to_their_parents(void) {
+    struct pid_stat *p, *pp;
+
+    // link all children to their parents
+    // and update children count on parents
+    for(p = root_of_pids; p ; p = p->next) {
+        // for each process found
+
+        p->sortlist = 0;
+        p->parent = NULL;
+
+        if(unlikely(!p->ppid)) {
+            p->parent = NULL;
+            continue;
+        }
+
+        pp = all_pids[p->ppid];
+        if(likely(pp)) {
+            p->parent = pp;
+            pp->children_count++;
+
+            if(unlikely(debug_enabled || (p->target && p->target->debug_enabled)))
+                debug_log_int("child %d (%s, %s) on target '%s' has parent %d (%s, %s).", p->pid, p->comm, p->updated?"running":"exited", (p->target)?p->target->name:"UNSET", pp->pid, pp->comm, pp->updated?"running":"exited");
+        }
+        else {
+            p->parent = NULL;
+            error("pid %d %s states parent %d, but the later does not exist.", p->pid, p->comm, p->ppid);
+        }
+    }
+}
+
+static void apply_apps_groups_targets_inheritance(void) {
+    struct pid_stat *p = NULL;
+
+    // children that do not have a target
+    // inherit their target from their parent
+    int found = 1, loops = 0;
+    while(found) {
+        if(unlikely(debug_enabled)) loops++;
+        found = 0;
+        for(p = root_of_pids; p ; p = p->next) {
+            // if this process does not have a target
+            // and it has a parent
+            // and its parent has a target
+            // then, set the parent's target to this process
+            if(unlikely(!p->target && p->parent && p->parent->target)) {
+                p->target = p->parent->target;
+                found++;
+
+                if(debug_enabled || (p->target && p->target->debug_enabled))
+                    debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s).", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
+            }
+        }
+    }
+
+    // find all the procs with 0 childs and merge them to their parents
+    // repeat, until nothing more can be done.
+    int sortlist = 1;
+    found = 1;
+    while(found) {
+        if(unlikely(debug_enabled)) loops++;
+        found = 0;
+
+        for(p = root_of_pids; p ; p = p->next) {
+            if(unlikely(!p->sortlist && !p->children_count))
+                p->sortlist = sortlist++;
+
+            if(unlikely(
+                    !p->children_count            // if this process does not have any children
+                    && !p->merged                 // and is not already merged
+                    && p->parent                  // and has a parent
+                    && p->parent->children_count  // and its parent has children
+                                                  // and the target of this process and its parent is the same,
+                                                  // or the parent does not have a target
+                    && (p->target == p->parent->target || !p->parent->target)
+                    && p->ppid != INIT_PID        // and its parent is not init
+                )) {
+                // mark it as merged
+                p->parent->children_count--;
+                p->merged = 1;
+
+                // the parent inherits the child's target, if it does not have a target itself
+                if(unlikely(p->target && !p->parent->target)) {
+                    p->parent->target = p->target;
+
+                    if(debug_enabled || (p->target && p->target->debug_enabled))
+                        debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its child %d (%s).", p->target->name, p->parent->pid, p->parent->comm, p->pid, p->comm);
+                }
+
+                found++;
+            }
+        }
+
+        debug_log("TARGET INHERITANCE: merged %d processes", found);
+    }
+
+    // init goes always to default target
+    if(all_pids[INIT_PID])
+        all_pids[INIT_PID]->target = apps_groups_default_target;
+
+    // pid 0 goes always to default target
+    if(all_pids[0])
+        all_pids[0]->target = apps_groups_default_target;
+
+    // give a default target on all top level processes
+    if(unlikely(debug_enabled)) loops++;
+    for(p = root_of_pids; p ; p = p->next) {
+        // if the process is not merged itself
+        // then is is a top level process
+        if(unlikely(!p->merged && !p->target))
+            p->target = apps_groups_default_target;
+
+        // make sure all processes have a sortlist
+        if(unlikely(!p->sortlist))
+            p->sortlist = sortlist++;
+    }
+
+    if(all_pids[1])
+        all_pids[1]->sortlist = sortlist++;
+
+    // give a target to all merged child processes
+    found = 1;
+    while(found) {
+        if(unlikely(debug_enabled)) loops++;
+        found = 0;
+        for(p = root_of_pids; p ; p = p->next) {
+            if(unlikely(!p->target && p->merged && p->parent && p->parent->target)) {
+                p->target = p->parent->target;
+                found++;
+
+                if(debug_enabled || (p->target && p->target->debug_enabled))
+                    debug_log_int("TARGET INHERITANCE: %s is inherited by %d (%s) from its parent %d (%s) at phase 2.", p->target->name, p->pid, p->comm, p->parent->pid, p->parent->comm);
+            }
+        }
+    }
+
+    debug_log("apply_apps_groups_targets_inheritance() made %d loops on the process tree", loops);
+}
+
+static inline void post_aggregate_targets(struct target *root) {
+    struct target *w;
+    for (w = root; w ; w = w->next) {
+        if(w->collected_starttime) {
+            if (!w->starttime || w->collected_starttime < w->starttime) {
+                w->starttime = w->collected_starttime;
+            }
+        } else {
+            w->starttime = 0;
+        }
+    }
+}
+
+static inline void del_pid_entry(pid_t pid) {
+    struct pid_stat *p = all_pids[pid];
+
+    if(unlikely(!p)) {
+        error("attempted to free pid %d that is not allocated.", pid);
+        return;
+    }
+
+    debug_log("process %d %s exited, deleting it.", pid, p->comm);
+
+    if(root_of_pids == p)
+        root_of_pids = p->next;
+
+    if(p->next) p->next->prev = p->prev;
+    if(p->prev) p->prev->next = p->next;
+
+    freez(p->stat_filename);
+    freez(p->status_filename);
+    freez(p->io_filename);
+    freez(p->cmdline_filename);
+    freez(p->cmdline);
+    freez(p);
+
+    all_pids[pid] = NULL;
+    all_pids_count--;
+}
+
+static void cleanup_exited_pids(void) {
+    struct pid_stat *p = NULL;
+
+    for(p = root_of_pids; p ;) {
+        if(!p->updated && (!p->keep || p->keeploops > 0)) {
+            if(unlikely(debug_enabled && (p->keep || p->keeploops)))
+                debug_log(" > CLEANUP cannot keep exited process %d (%s) anymore - removing it.", p->pid, p->comm);
+
+            pid_t r = p->pid;
+            p = p->next;
+            del_pid_entry(r);
+        }
+        else {
+            if(unlikely(p->keep)) p->keeploops++;
+            p->keep = 0;
+            p = p->next;
+        }
+    }
+}
+
+int collect_data_for_all_processes(
+    int (*bpf_map_get_next_key)(int, const void *, void *), int (*bpf_map_lookup_elem)(int, const void *, void *),
+    int tbl_pid_stats_fd)
+{
+    pid_t key, next_key;
+    ebpf_process_stat_t *value = NULL;
+
+    while (bpf_map_get_next_key(tbl_pid_stats_fd, &key, &next_key) == 0) {
+        if (!bpf_map_lookup_elem(tbl_pid_stats_fd, &next_key, value)) {
+            if (value)
+                collect_data_for_pid(next_key, NULL);
+        }
+        next_key = key;
+    }
+
+    link_all_processes_to_their_parents();
+
+    apply_apps_groups_targets_inheritance();
+
+    zero_all_targets(users_root_target);
+    zero_all_targets(groups_root_target);
+    apps_groups_targets_count = zero_all_targets(apps_groups_root_target);
+
+    // // this has to be done, before the cleanup
+    // struct pid_stat *p = NULL;
+    // struct target *w = NULL, *o = NULL;
+
+    // // concentrate everything on the targets
+    // for(p = root_of_pids; p ; p = p->next) {
+
+    //     // --------------------------------------------------------------------
+    //     // apps_groups target
+
+    //     aggregate_pid_on_target(p->target, p, NULL);
+
+
+    //     // --------------------------------------------------------------------
+    //     // user target
+
+    //     o = p->user_target;
+    //     if(likely(p->user_target && p->user_target->uid == p->uid))
+    //         w = p->user_target;
+    //     else {
+    //         if(unlikely(debug_enabled && p->user_target))
+    //             debug_log("pid %d (%s) switched user from %u (%s) to %u.", p->pid, p->comm, p->user_target->uid, p->user_target->name, p->uid);
+
+    //         w = p->user_target = get_users_target(p->uid);
+    //     }
+
+    //     aggregate_pid_on_target(w, p, o);
+
+
+    //     // --------------------------------------------------------------------
+    //     // user group target
+
+    //     o = p->group_target;
+    //     if(likely(p->group_target && p->group_target->gid == p->gid))
+    //         w = p->group_target;
+    //     else {
+    //         if(unlikely(debug_enabled && p->group_target))
+    //             debug_log("pid %d (%s) switched group from %u (%s) to %u.", p->pid, p->comm, p->group_target->gid, p->group_target->name, p->gid);
+
+    //         w = p->group_target = get_groups_target(p->gid);
+    //     }
+
+    //     aggregate_pid_on_target(w, p, o);
+
+
+    //     // --------------------------------------------------------------------
+    //     // aggregate all file descriptors
+
+    //     if(enable_file_charts)
+    //         aggregate_pid_fds_on_targets(p);
+    // }
+
+    post_aggregate_targets(apps_groups_root_target);
+    post_aggregate_targets(users_root_target);
+    post_aggregate_targets(groups_root_target);
+
+    cleanup_exited_pids();
+
+    return 0;
+}

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -379,6 +379,10 @@ extern size_t zero_all_targets(struct target *root);
 
 extern int am_i_running_as_root();
 
+int collect_data_for_all_processes(
+    int (*bpf_map_get_next_key)(int, const void *, void *), int (*bpf_map_lookup_elem)(int, const void *, void *),
+    int tbl_pid_stats_fd);
+
 #ifndef STATIC
 extern int ebpf_read_hash_table(void *ep, int fd, uint32_t pid,
                            int (*bpf_map_lookup_elem)(int, const void *, void *));

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -1,12 +1,12 @@
 #ifndef _NETDATA_EBPF_APPS_H
 # define _NETDATA_EBPF_APPS_H 1
 
-# include "../../libnetdata/threads/threads.h"
-# include "../../libnetdata/locks/locks.h"
-# include "../../libnetdata/avl/avl.h"
-# include "../../libnetdata/clocks/clocks.h"
-# include "../../libnetdata/config/appconfig.h"
-# include "../../libnetdata/ebpf/ebpf.h"
+# include "libnetdata/threads/threads.h"
+# include "libnetdata/locks/locks.h"
+# include "libnetdata/avl/avl.h"
+# include "libnetdata/clocks/clocks.h"
+# include "libnetdata/config/appconfig.h"
+# include "libnetdata/ebpf/ebpf.h"
 
 # define NETDATA_APPS_FAMILY "apps"
 # define NETDATA_APPS_SYSCALL_GROUP "ebpf syscall"
@@ -87,16 +87,99 @@ struct pid_fd {
 #endif
 };
 
+struct target {
+    char compare[MAX_COMPARE_NAME + 1];
+    uint32_t comparehash;
+    size_t comparelen;
+
+    char id[MAX_NAME + 1];
+    uint32_t idhash;
+
+    char name[MAX_NAME + 1];
+
+    uid_t uid;
+    gid_t gid;
+
+    /* These variables are not necessary for eBPF collector
+    kernel_uint_t minflt;
+    kernel_uint_t cminflt;
+    kernel_uint_t majflt;
+    kernel_uint_t cmajflt;
+    kernel_uint_t utime;
+    kernel_uint_t stime;
+    kernel_uint_t gtime;
+    kernel_uint_t cutime;
+    kernel_uint_t cstime;
+    kernel_uint_t cgtime;
+    kernel_uint_t num_threads;
+    // kernel_uint_t rss;
+
+    kernel_uint_t status_vmsize;
+    kernel_uint_t status_vmrss;
+    kernel_uint_t status_vmshared;
+    kernel_uint_t status_rssfile;
+    kernel_uint_t status_rssshmem;
+    kernel_uint_t status_vmswap;
+
+    kernel_uint_t io_logical_bytes_read;
+    kernel_uint_t io_logical_bytes_written;
+    // kernel_uint_t io_read_calls;
+    // kernel_uint_t io_write_calls;
+    kernel_uint_t io_storage_bytes_read;
+    kernel_uint_t io_storage_bytes_written;
+    // kernel_uint_t io_cancelled_write_bytes;
+
+    int *target_fds;
+    int target_fds_size;
+
+    kernel_uint_t openfiles;
+    kernel_uint_t openpipes;
+    kernel_uint_t opensockets;
+    kernel_uint_t openinotifies;
+    kernel_uint_t openeventfds;
+    kernel_uint_t opentimerfds;
+    kernel_uint_t opensignalfds;
+    kernel_uint_t openeventpolls;
+    kernel_uint_t openother;
+    */
+
+    kernel_uint_t starttime;
+    kernel_uint_t collected_starttime;
+
+    /*
+    kernel_uint_t uptime_min;
+    kernel_uint_t uptime_sum;
+    kernel_uint_t uptime_max;
+    */
+
+    unsigned int processes; // how many processes have been merged to this
+    int exposed;            // if set, we have sent this to netdata
+    int hidden;             // if set, we set the hidden flag on the dimension
+    int debug_enabled;
+    int ends_with;
+    int starts_with;        // if set, the compare string matches only the
+                            // beginning of the command
+
+    struct pid_on_target *root_pid; // list of aggregated pids for target debugging
+
+    struct target *target;  // the one that will be reported to netdata
+    struct target *next;
+};
+
+extern struct target *apps_groups_default_target;
+extern struct target *apps_groups_root_target;
+
 struct pid_stat {
     int32_t pid;
     char comm[MAX_COMPARE_NAME + 1];
     char *cmdline;
 
-    /* These variables are not necessary for eBPF collector
     uint32_t log_thrown;
 
     // char state;
     int32_t ppid;
+
+    /* These variables are not necessary for eBPF collector
     // int32_t pgrp;
     // int32_t session;
     // int32_t tty_nr;
@@ -184,6 +267,7 @@ struct pid_stat {
 
     struct pid_fd *fds;             // array of fds it uses
     size_t fds_size;                   // the size of the fds array
+    */
 
     int children_count;             // number of processes directly referencing this
     unsigned char keep:1;           // 1 when we need to keep this process in memory even after it exited
@@ -193,6 +277,7 @@ struct pid_stat {
     unsigned char read:1;           // 1 when we have already read this process for this iteration
 
     int sortlist;                   // higher numbers = top on the process tree
+
     // each process gets a unique number
 
     struct target *target;          // app_groups.conf targets
@@ -201,6 +286,7 @@ struct pid_stat {
 
     usec_t stat_collected_usec;
     usec_t last_stat_collected_usec;
+    /*
 
     usec_t io_collected_usec;
     usec_t last_io_collected_usec;
@@ -208,7 +294,7 @@ struct pid_stat {
     kernel_uint_t uptime;
 
     char *fds_dirname;              // the full directory name in /proc/PID/fd
-     */
+    */
 
     char *stat_filename;
     char *status_filename;
@@ -231,82 +317,6 @@ struct pid_stat {
 struct pid_on_target {
     int32_t pid;
     struct pid_on_target *next;
-};
-
-struct target {
-    char compare[MAX_COMPARE_NAME + 1];
-    uint32_t comparehash;
-    size_t comparelen;
-
-    char id[MAX_NAME + 1];
-    uint32_t idhash;
-
-    char name[MAX_NAME + 1];
-
-    uid_t uid;
-    gid_t gid;
-
-    /* These variables are not necessary for eBPF collector
-    kernel_uint_t minflt;
-    kernel_uint_t cminflt;
-    kernel_uint_t majflt;
-    kernel_uint_t cmajflt;
-    kernel_uint_t utime;
-    kernel_uint_t stime;
-    kernel_uint_t gtime;
-    kernel_uint_t cutime;
-    kernel_uint_t cstime;
-    kernel_uint_t cgtime;
-    kernel_uint_t num_threads;
-    // kernel_uint_t rss;
-
-    kernel_uint_t status_vmsize;
-    kernel_uint_t status_vmrss;
-    kernel_uint_t status_vmshared;
-    kernel_uint_t status_rssfile;
-    kernel_uint_t status_rssshmem;
-    kernel_uint_t status_vmswap;
-
-    kernel_uint_t io_logical_bytes_read;
-    kernel_uint_t io_logical_bytes_written;
-    // kernel_uint_t io_read_calls;
-    // kernel_uint_t io_write_calls;
-    kernel_uint_t io_storage_bytes_read;
-    kernel_uint_t io_storage_bytes_written;
-    // kernel_uint_t io_cancelled_write_bytes;
-
-    int *target_fds;
-    int target_fds_size;
-
-    kernel_uint_t openfiles;
-    kernel_uint_t openpipes;
-    kernel_uint_t opensockets;
-    kernel_uint_t openinotifies;
-    kernel_uint_t openeventfds;
-    kernel_uint_t opentimerfds;
-    kernel_uint_t opensignalfds;
-    kernel_uint_t openeventpolls;
-    kernel_uint_t openother;
-
-    kernel_uint_t starttime;
-    kernel_uint_t collected_starttime;
-    kernel_uint_t uptime_min;
-    kernel_uint_t uptime_sum;
-    kernel_uint_t uptime_max;
-                            */
-
-    unsigned int processes; // how many processes have been merged to this
-    int exposed;            // if set, we have sent this to netdata
-    int hidden;             // if set, we set the hidden flag on the dimension
-    int debug_enabled;
-    int ends_with;
-    int starts_with;        // if set, the compare string matches only the
-                            // beginning of the command
-
-    struct pid_on_target *root_pid; // list of aggregated pids for target debugging
-
-    struct target *target;  // the one that will be reported to netdata
-    struct target *next;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
We need to attach all pids from the `tbl_pid_stats` eBPF hash map to targets configured in `apps_groups.conf`.

##### Component Name
eBPF plugin